### PR TITLE
Use relative paths when working filenames

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,12 @@ import os
 from setuptools import Extension, find_packages, setup
 
 from Cython.Build import cythonize  # isort: skip
-
-
-__version__ = "0.2.0a1"
+from Cython.Compiler import Options  # isort: skip
 
 
 TRACE_LINES = os.getenv("TRACE_LINES")
+
+Options.cimport_from_pyx = True
 
 extensions = [
     Extension(
@@ -43,7 +43,7 @@ docs_requires = [
 
 setup(
     name="django-trackings",
-    version=__version__,
+    version="0.2.0a1",
     description="A Django app that tracks your queries to help optimize them.",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/src/dj_tracker/cache_utils.pyx
+++ b/src/dj_tracker/cache_utils.pyx
@@ -1,0 +1,80 @@
+from cpython.dict cimport PyDict_Next
+from cpython.object cimport PyObject
+
+
+class cached_attribute:
+    """
+    This is similar to `cached_property` but for classes rather than class instances.
+    """
+
+    def __init__(self, func):
+        self.func = func
+
+    def __set_name__(self, owner, name):
+        self.name = name
+
+    def __get__(self, instance, cls):
+        if not cls:
+            cls = type(instance)
+
+        result = self.func(cls)
+        setattr(cls, self.name, result)
+        return result
+
+
+class LazySlots(type):
+    def __new__(cls, name, bases, namespace, **kwargs):
+        if lazy_slots := namespace.get("lazy_slots"):
+            lazy_slots = {
+                name: namespace.pop(name)
+                for name, meth in tuple(namespace.items())
+                if meth in lazy_slots
+            }
+
+            def __getattr__(self, attr, dict lazy_slots=lazy_slots):
+                if (method := lazy_slots.get(attr)) is not None:
+                    result = method(self)
+                    setattr(self, attr, result)
+                    return result
+
+                raise AttributeError(attr)
+
+            namespace.update(
+                __getattr__=__getattr__,
+                __slots__=(*namespace.get("__slots__", ()), *lazy_slots),
+            )
+
+        return super().__new__(cls, name, bases, namespace, **kwargs)
+
+
+cdef class LRUCache:
+    cdef:
+        dict cache
+        int maxsize
+
+    def __cinit__(self, int maxsize=256):
+        self.cache = {}
+        self.maxsize = maxsize
+
+    cpdef get(self, key):
+        if (value := self.cache.pop(key, None)) is not None:
+            self.cache[key] = value
+            return value
+    
+    cpdef set(self, key, value):
+        cdef:
+            PyObject *lru_key
+            Py_ssize_t pos = 0
+            dict cache = self.cache
+
+        if len(cache) == self.maxsize:
+            PyDict_Next(cache, &pos, &lru_key, NULL)
+            del cache[<object>lru_key]
+
+        cache[key] = value
+    
+    def __len__(self):
+        return len(self.cache)
+
+    def __repr__(self):
+        return f"LRUCache({self.cache})"

--- a/src/dj_tracker/datastructures.py
+++ b/src/dj_tracker/datastructures.py
@@ -8,6 +8,7 @@ from itertools import chain
 from django.db import transaction
 from django.utils.timezone import now
 
+from dj_tracker.cache_utils import LazySlots, cached_attribute
 from dj_tracker.collector import Collector
 from dj_tracker.constants import DUMMY_REQUEST, TRACKINGS_DB
 from dj_tracker.context import get_request
@@ -15,7 +16,6 @@ from dj_tracker.hash_utils import HashableCounter, HashableMixin
 from dj_tracker.models import QueryGroup, QuerySetTracking, Tracking
 from dj_tracker.promise import QueryGroupPromise, QueryPromise, RequestPromise
 from dj_tracker.traceback import get_traceback
-from dj_tracker.utils import LazySlots, cached_attribute
 
 weak_reference = weakref.ref
 weakref_finalize = weakref.finalize

--- a/src/dj_tracker/db_router.py
+++ b/src/dj_tracker/db_router.py
@@ -1,6 +1,6 @@
 from django.apps import apps
 
-from dj_tracker.utils import cached_attribute
+from dj_tracker.cache_utils import cached_attribute
 
 
 class DjTrackerRouter:

--- a/src/dj_tracker/hash_utils.pyx
+++ b/src/dj_tracker/hash_utils.pyx
@@ -1,6 +1,6 @@
 from collections import Counter
 
-from dj_tracker.utils import LazySlots
+from dj_tracker.cache_utils import LazySlots
 
 
 class HashableMixin(metaclass=LazySlots):

--- a/src/dj_tracker/traceback.pyx
+++ b/src/dj_tracker/traceback.pyx
@@ -2,7 +2,8 @@ cimport cython
 from cpython.object cimport PyObject
 from cpython.pystate cimport PyFrameObject
 
-from functools import lru_cache
+import os
+import sys
 from linecache import getline
 
 from django.template import Node
@@ -29,6 +30,7 @@ cdef extern from "Python.h":
 cdef extern from "pythoncapi_compat.h":
     PyFrameObject *PyFrame_GetBack(PyFrameObject*)
     PyCodeObject *PyFrame_GetCode(PyFrameObject*)
+    PyObject *PyFrame_GetGlobals(PyFrameObject*)
     PyObject *PyFrame_GetVar(PyFrameObject*, PyObject*)
 
 
@@ -36,27 +38,30 @@ cdef extern from "pythoncapi_compat.h":
 cdef class TracebackEntry:
     cdef:
         readonly str filename
+        readonly str rel_path
         readonly int lineno
         readonly str func
 
-        int hash_value
         bint ignore
         bint is_render
 
-    def __init__(self, str filename, int lineno, str func=""):
+        int hash_value
+
+    def __init__(self, str filename, str rel_path, bint ignore, int lineno, str func):
         self.filename = filename
+        self.rel_path = rel_path
+        self.ignore = ignore
         self.lineno = lineno
         self.func = func
-        self.ignore = ignore_file(filename)
         self.is_render = func == "render"
+
+    @property
+    def filename_id(self):
+        return SourceFilePromise.get_or_create(name=self.rel_path)
 
     @property
     def code(self):
         return getline(self.filename, self.lineno).strip()
-
-    @property
-    def filename_id(self):
-        return SourceFilePromise.get_or_create(name=self.filename)
 
     @property
     def cache_key(self):
@@ -71,26 +76,65 @@ cdef class TracebackEntry:
     
     def __getattr__(self, name):
         if name == "hash_value":
-            self.hash_value = hash_value = hash((self.filename, self.lineno))
-            return hash_value
-        raise AttributeError
+            self.hash_value = hash((self.rel_path, self.lineno))
+            return self.hash_value
 
-    def __repr__(self):
-        return f"{self.filename} {self.code}"
+        raise AttributeError(name)
+
+
+cdef tuple get_file_info(str filename, PyFrameObject *frame, dict cache = {}):
+    """Retrieves the relative path for a filename and indicates if it should be ignored."""
+
+    cdef:
+        str rel_path
+        bint ignore
+
+    if (file_info := cache.get(filename)) is None:
+        try:
+            module_dir = next(path for path in sys.path if filename.startswith(path))
+        except StopIteration:
+            # The following logic is inspired from:
+            # https://github.com/scoutapp/scout_apm_python/blob/master/src/scout_apm/core/backtrace.py#L29
+            f_globals = PyFrame_GetGlobals(frame)
+            module = (<dict>f_globals).get("__name__", "")
+            Py_DECREF(f_globals)
+
+            if (root_module := sys.modules.get(module.split(".", 1)[0])) is not None:
+                if module_path := root_module.__file__:
+                    module_dir = module_path.rsplit(os.sep, 2)[0]
+                elif (module_path := root_module.__path__) and isinstance(module_path, (list, tuple)):
+                    module_dir = module_path[0].rsplit(os.sep, 1)[0]
+            else:
+                # Fall back to current working directory.
+                module_dir = os.getcwd()
+
+        rel_path = os.path.relpath(filename, module_dir)
+        ignore = any(module in filename for module in IGNORED_MODULES)
+        cache[filename] = file_info = rel_path, ignore
+
+    return file_info
 
 
 cdef inline TracebackEntry get_entry(
     str filename,
     object lineno,
+    PyFrameObject *frame,
     PyCodeObject *code = NULL,
-    LRUCache entries = LRUCache(maxsize=512)
+    LRUCache cache = LRUCache(maxsize=512)
 ):
-    cdef TracebackEntry entry
+    cdef:
+        TracebackEntry entry
+        PyObject *f_globals
 
     cache_key = filename, lineno
-    if (entry := entries.get(cache_key)) is None:
-        entry = TracebackEntry(filename, lineno, <object>code.co_name if code else "")
-        entries.set(cache_key, entry)
+    if (entry := cache.get(cache_key)) is None:
+        entry = TracebackEntry(
+            filename,
+            *get_file_info(filename, frame),
+            lineno,
+            <object>code.co_name if code else "",
+        )
+        cache.set(cache_key, entry)
 
     return entry
 
@@ -117,7 +161,7 @@ cpdef get_traceback():
         last_frame = frame
 
         code = PyFrame_GetCode(frame)
-        entry = get_entry(<object>code.co_filename, PyFrame_GetLineNumber(frame), code)
+        entry = get_entry(<object>code.co_filename, PyFrame_GetLineNumber(frame), frame, code)
         Py_DECREF(<PyObject*>code)
 
         if template_info is None and entry.is_render:
@@ -128,7 +172,7 @@ cpdef get_traceback():
             else:
                 node_obj = <object>node
                 if isinstance(node_obj, Node):
-                    template_info = get_entry(node_obj.origin.name, node_obj.token.lineno)
+                    template_info = get_entry(node_obj.origin.name, node_obj.token.lineno, frame)
                 Py_DECREF(node)
 
         if entry.ignore:
@@ -149,9 +193,3 @@ cpdef get_traceback():
         stack[-num_bottom_entries:] = []
 
     return stack, template_info
-
-
-@lru_cache(maxsize=None)
-def ignore_file(filename: str) -> bool:
-    """Indicates whether the frame containing the given filename should be ignored."""
-    return any(module in filename for module in IGNORED_MODULES)

--- a/src/dj_tracker/utils.py
+++ b/src/dj_tracker/utils.py
@@ -3,80 +3,10 @@ import itertools
 import linecache
 import operator
 import weakref
-from collections import OrderedDict, defaultdict
+from collections import defaultdict
 from sys import settrace, stdout
 from time import perf_counter_ns as now
 from types import MethodType
-
-
-class cached_attribute:
-    """
-    This is similar to `cached_property` but for classes rather than class instances.
-    """
-
-    def __init__(self, func):
-        self.func = func
-
-    def __set_name__(self, owner, name):
-        self.name = name
-
-    def __get__(self, instance, cls):
-        if not cls:
-            cls = type(instance)
-
-        result = self.func(cls)
-        setattr(cls, self.name, result)
-        return result
-
-
-class LRUBoundedDict(OrderedDict):
-    def __init__(self, maxsize=256):
-        super().__init__()
-        self.maxsize = maxsize
-
-    def get(self, key, dict_get=dict.get, move_to_end=OrderedDict.move_to_end):
-        if value := dict_get(self, key):
-            move_to_end(self, key)
-        return value
-
-    def __setitem__(
-        self,
-        key,
-        value,
-        len=dict.__len__,
-        odict_popitem=OrderedDict.popitem,
-        odict_setitem=OrderedDict.__setitem__,
-    ):
-        odict_setitem(self, key, value)
-        if len(self) > self.maxsize:
-            odict_popitem(self, False)
-
-
-class LazySlots(type):
-    def __new__(cls, name, bases, namespace, **kwargs):
-        if lazy_slots := namespace.get("lazy_slots"):
-            lazy_slots = {
-                name: namespace.pop(name)
-                for name, meth in tuple(namespace.items())
-                if meth in lazy_slots
-            }
-            get_method_for_slot = lazy_slots.get
-            set_attr = setattr
-
-            def __getattr__(self, attr):
-                if method := get_method_for_slot(attr):
-                    result = method(self)
-                    set_attr(self, attr, result)
-                    return result
-
-                raise AttributeError
-
-            namespace.update(
-                __getattr__=__getattr__,
-                __slots__=(*namespace.get("__slots__", ()), *lazy_slots),
-            )
-
-        return super().__new__(cls, name, bases, namespace, **kwargs)
 
 
 class profile:

--- a/tests/test_cache_utils.py
+++ b/tests/test_cache_utils.py
@@ -1,0 +1,30 @@
+import unittest
+
+from dj_tracker.cache_utils import LRUCache
+
+
+class LRUCacheTest(unittest.TestCase):
+    def test(self):
+        cache = LRUCache(maxsize=2)
+
+        cache.set(1, 1)
+        cache.set(2, 2)
+        cache.set(3, 3)
+
+        self.assertEqual(len(cache), 2)
+        self.assertIsNone(cache.get(1))
+        self.assertEqual(cache.get(2), 2)
+        self.assertEqual(cache.get(3), 3)
+
+        cache.get(2)
+        cache.set(4, 4)
+        self.assertEqual(len(cache), 2)
+        self.assertIsNone(cache.get(3))
+        self.assertEqual(cache.get(2), 2)
+        self.assertEqual(cache.get(4), 4)
+
+        cache.set(5, 5)
+        self.assertEqual(len(cache), 2)
+        self.assertIsNone(cache.get(2))
+        self.assertEqual(cache.get(4), 4)
+        self.assertEqual(cache.get(5), 5)


### PR DESCRIPTION
Using the absolute file path in tracebacks will result in different model instances being created when the tracker is run on different machines or using a locally installed package for example, although they represent the same file for our purposes.

The goal of this PR is to use the relative path when creating traceback entries.